### PR TITLE
Add configurable file logging for external log aggregation

### DIFF
--- a/pr_agent/log/__init__.py
+++ b/pr_agent/log/__init__.py
@@ -46,6 +46,20 @@ def setup_logger(level: str = "INFO", fmt: LoggingFormat = LoggingFormat.CONSOLE
         logger.remove(None)
         logger.add(sys.stdout, level=level, colorize=True, filter=inv_analytics_filter)
 
+    # Optional file logging for all logs (useful for log aggregation systems like logstash)
+    # Format: timestamp level [module] message (compatible with traditional log parsers)
+    log_file_path = get_settings().get("CONFIG.LOG_FILE", "") or os.getenv("LOG_FILE", "")
+    if log_file_path:
+        logger.add(
+            log_file_path,
+            filter=inv_analytics_filter,  # Exclude analytics events (already logged separately if analytics_folder is set)
+            level=level,
+            format="{time:YYYY-MM-DD HH:mm:ss} {level: <8} [{name}] {message}",
+            colorize=False,
+            enqueue=True,  # Async writing for better performance
+            # Note: rotation/retention not configured - use external logrotate instead
+        )
+
     log_folder = get_settings().get("CONFIG.ANALYTICS_FOLDER", "")
     if log_folder:
         pid = os.getpid()

--- a/pr_agent/settings/configuration.toml
+++ b/pr_agent/settings/configuration.toml
@@ -18,6 +18,7 @@ verbosity_level=0 # 0,1,2
 use_extra_bad_extensions=false
 # Log
 log_level="DEBUG"
+log_file=""  # Optional: Path to log file for external log aggregation (e.g., "/var/log/python/pr-agent.log"). Can also be set via LOG_FILE env var. Logs go to stdout by default.
 # Configurations
 use_wiki_settings_file=true
 use_repo_settings_file=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pr-agent"
-version = "1.3.0"
+version = "1.4.0"
 
 authors = [{ name = "QodoAI", email = "ofir.f@qodo.ai" }]
 

--- a/tests/unittest/test_file_logging.py
+++ b/tests/unittest/test_file_logging.py
@@ -1,0 +1,105 @@
+import os
+import tempfile
+import pytest
+import time
+
+# IMPORTANT: Import config_loader before log to avoid circular dependency
+from pr_agent.config_loader import get_settings
+from pr_agent.log import setup_logger, get_logger, LoggingFormat
+
+
+class TestFileLogging:
+    """Test file logging functionality with configurable LOG_FILE"""
+
+    def test_file_logging_with_env_var(self):
+        """Test that logs are written to file when LOG_FILE env var is set"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+            log_file = f.name
+
+        try:
+            # Set LOG_FILE environment variable
+            os.environ['LOG_FILE'] = log_file
+
+            # Setup logger
+            setup_logger(level="INFO", fmt=LoggingFormat.CONSOLE)
+
+            # Log test messages
+            get_logger().info("Test info message")
+            get_logger().error("Test error message")
+
+            # Wait for async write to complete
+            time.sleep(0.2)
+
+            # Verify file was created and contains messages
+            assert os.path.exists(log_file), f"Log file {log_file} was not created"
+
+            with open(log_file, 'r') as f:
+                content = f.read()
+                assert "Test info message" in content, "Info message not found in log file"
+                assert "Test error message" in content, "Error message not found in log file"
+                assert "INFO" in content, "Log level not found"
+                assert "ERROR" in content, "Error level not found"
+
+        finally:
+            # Cleanup
+            if 'LOG_FILE' in os.environ:
+                del os.environ['LOG_FILE']
+            if os.path.exists(log_file):
+                os.unlink(log_file)
+
+    def test_log_file_format(self):
+        """Test that log file uses correct format: timestamp level [module] message"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.log', delete=False) as f:
+            log_file = f.name
+
+        try:
+            # Set LOG_FILE environment variable
+            os.environ['LOG_FILE'] = log_file
+
+            # Setup logger
+            setup_logger(level="INFO", fmt=LoggingFormat.CONSOLE)
+
+            # Log a test message
+            get_logger().info("Format validation message")
+
+            # Wait for async write
+            time.sleep(0.2)
+
+            # Read and verify format
+            with open(log_file, 'r') as f:
+                content = f.read()
+
+                # Verify format components
+                assert "Format validation message" in content, "Message not found"
+                assert "[" in content and "]" in content, "Module markers not found"
+
+                # Verify timestamp format (YYYY-MM-DD HH:mm:ss)
+                import re
+                timestamp_pattern = r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+                assert re.search(timestamp_pattern, content), f"Timestamp not in expected format. Content: {content}"
+
+                # Verify level is padded to 8 characters
+                assert "INFO    " in content, "Log level not properly formatted"
+
+        finally:
+            # Cleanup
+            if 'LOG_FILE' in os.environ:
+                del os.environ['LOG_FILE']
+            if os.path.exists(log_file):
+                os.unlink(log_file)
+
+    def test_no_file_logging_without_env_var(self):
+        """Test that no file is created when LOG_FILE is not set"""
+        # Ensure LOG_FILE is not set
+        if 'LOG_FILE' in os.environ:
+            del os.environ['LOG_FILE']
+
+        # Setup logger without LOG_FILE
+        setup_logger(level="INFO", fmt=LoggingFormat.CONSOLE)
+
+        # Log a message
+        get_logger().info("This should only go to stdout")
+
+        # Verify no unexpected log file was created in current directory
+        # (This is a basic check; a more thorough test would check all possible locations)
+        assert not os.path.exists("pr-agent.log"), "Unexpected log file created"

--- a/uv.lock
+++ b/uv.lock
@@ -1705,7 +1705,7 @@ wheels = [
 
 [[package]]
 name = "pr-agent"
-version = "0.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
This PR implements optional file logging functionality to enable log aggregation for centralized logging platforms (e.g., logstash → Google Cloud Platform).

## Changes
- **File logging support**: Logs can now be written to both stdout and a file simultaneously
- **Configuration**: Configurable via `CONFIG.LOG_FILE` setting or `LOG_FILE` environment variable
- **Format**: Plain text format for compatibility with traditional log parsers: `YYYY-MM-DD HH:mm:ss LEVEL [module] message`
- **Performance**: Async file writing with `enqueue=True` for non-blocking I/O
- **Backward compatible**: Defaults to stdout-only logging (existing behavior)
- **Test coverage**: Added integration tests for file logging functionality
- **Version bump**: 1.3.0 → 1.4.0

## Key Features
- ✅ Dual output: stdout + file when LOG_FILE is configured
- ✅ Analytics events excluded from file logs (already logged separately)
- ✅ Compatible with external logrotate (no built-in rotation)
- ✅ Zero impact when not configured (default behavior unchanged)

## Configuration Example
```yaml
# Kubernetes deployment
env:
  - name: LOG_FILE
    value: "/var/log/python/pr-agent.log"
```

Or in `.secrets.toml`:
```toml
[config]
log_file = "/var/log/python/pr-agent.log"
```

## Testing
Tested in production environment:
- Deployed to `non-prod-004760-platform-common` namespace
- Verified log file creation and format
- Confirmed application functionality with file logging enabled

## Files Changed
- `pr_agent/log/__init__.py`: Add file logging logic
- `pr_agent/settings/configuration.toml`: Add log_file configuration option
- `tests/unittest/test_file_logging.py`: Integration tests
- `pyproject.toml`: Version bump to 1.4.0
- `uv.lock`: Updated dependencies lock file